### PR TITLE
Add tests for getPythonBin function

### DIFF
--- a/Tests/pythonCheck.test.js
+++ b/Tests/pythonCheck.test.js
@@ -1,4 +1,4 @@
-const { getPythonBin } = require('./app/functions');
+const { getPythonBin } = require('../app/functions');
 const fs = require('fs');
 const { execSync } = require('child_process');
 const path = require('path');


### PR DESCRIPTION
Mock cases when different python installations exist or do not exist and test that python detection runs correctly.