### PR TITLE
Added workflow_dispatch to the CI run conditions.

### DIFF
--- a/.github/workflows/python-javascript-workflow.yml
+++ b/.github/workflows/python-javascript-workflow.yml
@@ -1,6 +1,6 @@
 name: Chesster CI
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 defaults:
   run:


### PR DESCRIPTION
This allows us to manually run the CI workflow from GitHub (not just on push and PR)